### PR TITLE
Adding mendelian error code

### DIFF
--- a/src/anhima/benchmark/benchmark_ped.py
+++ b/src/anhima/benchmark/benchmark_ped.py
@@ -3,19 +3,21 @@ import timeit
 # simulate genotypes 
 
 command = [
-    'import imp;',
+    #'import imp;',
     'import os;',
-    'import anhima;',
-    'ah = imp.load_source("anhima", os.path.join("src", "anhima", "ped.py"));',
+    'import anhima.ped;',
+    'import anhima.sim;',
+    #'ah = imp.load_source("anhima", os.path.join("src", "anhima", "ped.py"));',
     'import scipy.stats;',
     'n_samples = 10;',
     'n_variants = 10**6;',
     'ploidy = 2;',
     'af_dist = scipy.stats.beta(a=.9, b=.1);',
     'p_missing = .1;',
-    'parents = anhima.sim.simulate_biallelic_genotypes(n_variants, 2, af_dist, p_missing=0.1, ploidy=2);',
+    'parents = anhima.sim.simulate_biallelic_genotypes(n_variants, 2, '
+    'af_dist, p_missing=0.1, ploidy=2);',
     'progeny = anhima.sim.simulate_biallelic_genotypes(n_variants, n_samples, af_dist, p_missing=0.1, ploidy=2);',
-    'non_mendelian = ah.anhima.is_non_mendelian_diploid(parental_genotypes = parents, progeny_genotypes = progeny);'
-    ]
+    'non_mendelian = anhima.ped.diploid_mendelian_error(parental_genotypes=parents, progeny_genotypes=progeny);'
+]
 
 print timeit.timeit(" ".join(command), number=1)

--- a/src/anhima/test/test_ped.py
+++ b/src/anhima/test/test_ped.py
@@ -16,11 +16,11 @@ class TestMendelianError(unittest.TestCase):
         self.assertTrue(True)
 
     def test_function_exists(self):
-        self.assertTrue('is_non_mendelian_diploid' in dir(anhima.ped))
+        self.assertTrue('diploid_mendelian_error' in dir(anhima.ped))
 
     def test_homref_homref(self):
         parents = np.hstack([href_parent, href_parent])
-        non_mendelian = anhima.ped.is_non_mendelian_diploid(
+        non_mendelian = anhima.ped.diploid_mendelian_error(
             parental_genotypes=parents,
             progeny_genotypes=progeny
         )
@@ -30,7 +30,7 @@ class TestMendelianError(unittest.TestCase):
 
     def test_homref_het(self):
         parents = np.hstack([href_parent, het_parent])
-        non_mendelian = anhima.ped.is_non_mendelian_diploid(
+        non_mendelian = anhima.ped.diploid_mendelian_error(
             parental_genotypes=parents,
             progeny_genotypes=progeny
         )
@@ -39,7 +39,7 @@ class TestMendelianError(unittest.TestCase):
 
     def test_homref_homalt(self):
         parents = np.hstack([halt_parent, href_parent])
-        non_mendelian = anhima.ped.is_non_mendelian_diploid(
+        non_mendelian = anhima.ped.diploid_mendelian_error(
             parental_genotypes=parents,
             progeny_genotypes=progeny,
         )
@@ -48,7 +48,7 @@ class TestMendelianError(unittest.TestCase):
 
     def test_homalt_het(self):
         parents = np.hstack([halt_parent, het_parent])
-        non_mendelian = anhima.ped.is_non_mendelian_diploid(
+        non_mendelian = anhima.ped.diploid_mendelian_error(
             parental_genotypes=parents,
             progeny_genotypes=progeny,
         )
@@ -57,23 +57,47 @@ class TestMendelianError(unittest.TestCase):
 
     def test_homalt_homalt(self):
         parents = np.hstack([halt_parent, halt_parent])
-        non_mendelian = anhima.ped.is_non_mendelian_diploid(
+        non_mendelian = anhima.ped.diploid_mendelian_error(
             parental_genotypes=parents,
             progeny_genotypes=progeny
         )
         print non_mendelian[0]
         self.assertTrue(np.array_equal(non_mendelian[0], [2, 1, 0, 0]))
 
+    def test_multiple_variants(self):
+        parents = np.vstack([np.hstack([href_parent, href_parent]),
+                             np.hstack([halt_parent, halt_parent]),
+                             np.hstack([het_parent, halt_parent]),
+                             np.hstack([het_parent, het_parent])])
+
+        multiv_progeny = np.repeat(progeny, 4, axis=0)
+
+        non_mendelian = anhima.ped.diploid_mendelian_error(
+            parental_genotypes=parents,
+            progeny_genotypes=multiv_progeny
+        )
+
+        expected_result = np.array([[0, 1, 2, 0],
+                                    [2, 1, 0, 0],
+                                    [1, 0, 0, 0],
+                                    [0, 0, 0, 0]])
+
+        self.assertTrue(np.array_equal(parents.shape, (4, 2, 2)))
+        self.assertTrue(np.array_equal(non_mendelian.shape,
+                                       expected_result.shape))
+
+        self.assertTrue(np.array_equal(non_mendelian, expected_result))
+
     def test_error_multiallelic(self):
         parents = np.hstack([href_parent, halt_parent])
         progeny_multi = (
             np.array([[0, 2], [0, 1], [1, 2], [-1, -1]])
-            .reshape(1, -1, 2)
+            .reshape((1, -1, 2))
         )
 
         self.assertRaises(
             AssertionError,
-            anhima.ped.is_non_mendelian_diploid,
+            anhima.ped.diploid_mendelian_error,
             parental_genotypes=parents,
             progeny_genotypes=progeny_multi
         )


### PR DESCRIPTION
So, I gave up trying to be clever, and just went with much more straightforward and quicker approach. Basically I just convert to 0/1/2 and go from there. 
It doesn't support multiallelic sites, or anything other than diploid.

I think it is possible to write a fully generalizable function, but it's tricky to get it fast. 

Also added some tests and a benchmark script. 

---

Uses map and zip in leiu of loop.
Now assumes biallelic, diploid. In theory extensible to polyploid multiallelic, but too impractical for the moment.

Added test script run with nosetest test/ from the root dir.
Added benchmark script, run with python benchmark/benchmark_ped.py

for 1m variants, runs in approx 6 minutes for 10 samples. The more heterozygotes the slower it runs.
